### PR TITLE
Fixes issues 53-54

### DIFF
--- a/R/dolt-local-connection.R
+++ b/R/dolt-local-connection.R
@@ -129,11 +129,11 @@ setMethod("dbDisconnect", "DoltLocalConnection", function(conn, ...) {
 
   if (dbIsValid(conn) && ps_is_running(conn@server)) {
     # On disconnection, kill the server only if it was started by doltr and no
-    # no other processes connect to it
+    # no other processes connect to it.
 
     is_doltr_server <- isTRUE(ps_environ(conn@server)["R_DOLT"] == "1")
     procs <- ps()
-    procs <- procs[procs$status == "running" & procs$pid != ps_pid(ps_handle()),]
+    procs <- procs[(procs$status == "running" | procs$status == "sleeping") & procs$pid != ps_pid(ps_handle()),]
     procs <- procs[vapply(procs$ps_handle, function(x) {
       conns <- try(ps_connections(x), silent = TRUE)
       out <- !inherits(conns, "try-error") && nrow(conns) && conn@port %in% conns$lport

--- a/R/read-table.R
+++ b/R/read-table.R
@@ -57,7 +57,7 @@ setMethod("dbReadTable", c("DoltConnection", "character"),
 query_as_of <- function(query, as_of) {
   as_of <- tryCatch(
     paste0("TIMESTAMP('", as.character(as.POSIXct(as_of)), "')"),
-    error = function(e) paste("'", as_of, "'")
+    error = function(e) paste0("'", as_of, "'")
   )
   query <- paste0(query, " AS OF ", as_of)
   query

--- a/R/server.R
+++ b/R/server.R
@@ -181,7 +181,8 @@ dkill <- function(p = ps_handle) {
     ps_kill(p)
     unlink(paste0(ps::ps_cwd(p), "/.dolt/sql-server.lock"))
   } else {
-    ps_terminate(p) # sql-server.lock is cleaned up automatically
+    ps_terminate(p) # sql-server.lock should be cleaned up automatically. Just in case though...
+    unlink(paste0(ps::ps_cwd(p), "/.dolt/sql-server.lock"))
   }
 
   invisible(NULL)

--- a/R/utils.R
+++ b/R/utils.R
@@ -126,3 +126,9 @@ compact <- function(x) {
   is_empty <- vapply(x, function(x) length(x) == 0, logical(1))
   x[!is_empty]
 }
+
+get_table_type <- function(conn = NULL, name = NULL) {
+  if(is.null(conn) | is.null(name)) return(NULL)
+  out <- RMariaDB::dbGetQuery(conn, "select * from information_schema.tables")
+  out |> filter(TABLE_NAME == name) |> pull(TABLE_TYPE)
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -126,9 +126,3 @@ compact <- function(x) {
   is_empty <- vapply(x, function(x) length(x) == 0, logical(1))
   x[!is_empty]
 }
-
-get_table_type <- function(conn = NULL, name = NULL) {
-  if(is.null(conn) | is.null(name)) return(NULL)
-  out <- RMariaDB::dbGetQuery(conn, "select * from information_schema.tables")
-  out |> filter(TABLE_NAME == name) |> pull(TABLE_TYPE)
-}


### PR DESCRIPTION
Issue #53 will be fixed as soon as the DOLT team repairs union view `as of` capability. Doltr should now be ready for when that patch goes through. dbReadTable has been modified so that views use the `past data, past definition` mechanism for views outlined [here](https://github.com/dolthub/docs/pull/493/files) which is more intuitive but also obscures the ability to mix and match view definition and table commits.

DOLT issue: 
https://github.com/dolthub/dolt/issues/4011

DOLT PR:
https://github.com/dolthub/go-mysql-server/pull/1159