### PR TITLE
Hotfix/issue 41

### DIFF
--- a/R/dolt-nav.R
+++ b/R/dolt-nav.R
@@ -17,7 +17,7 @@ dolt_checkout <- function(branch, b = FALSE, start_point = NULL,
   branch = sql_quote(branch, "'")
   if (b) branch <- paste0(sql_quote("-b", "'"), ", ", branch)
   if (!is.null(start_point)) branch <- paste0(branch, ", ", start_point)
-  query <- paste0("select dolt_checkout(", branch, ")")
+  query <- paste0("call dolt_checkout(", branch, ")")
   dolt_query(query, conn, collect, show_sql)
   invisible(dolt_state())
 }

--- a/R/dolt-nav.R
+++ b/R/dolt-nav.R
@@ -18,8 +18,8 @@ dolt_checkout <- function(branch, b = FALSE, start_point = NULL,
   if (b) branch <- paste0(sql_quote("-b", "'"), ", ", branch)
   if (!is.null(start_point)) branch <- paste0(branch, ", ", start_point)
   query <- paste0("CALL dolt_checkout(", branch, ")")
-  dolt_query(query, conn, collect, show_sql, execute = T)
-  invisible(dolt_state())
+  dolt_call(query, conn, show_sql)
+  dolt_state() # I don't think this needs to be invisible.
 }
 
 #' @export

--- a/R/dolt-nav.R
+++ b/R/dolt-nav.R
@@ -17,8 +17,8 @@ dolt_checkout <- function(branch, b = FALSE, start_point = NULL,
   branch = sql_quote(branch, "'")
   if (b) branch <- paste0(sql_quote("-b", "'"), ", ", branch)
   if (!is.null(start_point)) branch <- paste0(branch, ", ", start_point)
-  query <- paste0("call dolt_checkout(", branch, ")")
-  dolt_query(query, conn, collect, show_sql)
+  query <- paste0("CALL dolt_checkout(", branch, ")")
+  dolt_query(query, conn, collect, show_sql, execute = T)
   invisible(dolt_state())
 }
 

--- a/R/dolt-remote.R
+++ b/R/dolt-remote.R
@@ -23,7 +23,7 @@ dolt_push <- function(remote = NULL, remote_branch = NULL, ref = NULL,
   if (!is.null (ref)) args <- c(args, sql_quote(ref, "'"))
   if (set_upstream) args <- c("'--set-upstream' ", args)
   if (force) args <- c(args, "'--force'")
-  query <- paste0("select dolt_push(", paste0(args, collapse = ", "), ")")
+  query <- paste0("call dolt_push(", paste0(args, collapse = ", "), ")")
   dolt_query(query, conn, collect, show_sql)
   invisible(dolt_state())
 }
@@ -39,7 +39,7 @@ dolt_pull <- function(remote = NULL, squash = FALSE, conn = dolt(),
   args <- ""
   if (!is.null(remote)) args <- c(args, sql_quote(remote, "'"))
   if (squash) args <- c(args, "'--squash'")
-  query <- paste0("select dolt_pull(", paste0(args, collapse = ", "), ")")
+  query <- paste0("call dolt_pull(", paste0(args, collapse = ", "), ")")
   dolt_query(query, conn, collect, show_sql)
   invisible(dolt_state())
 }
@@ -54,7 +54,7 @@ dolt_fetch <- function(remote = NULL, ref = FALSE, force = FALSE,
   if (!is.null(remote)) args <- c(args, sql_quote(remote, "'"))
   if (!is.null(ref)) args <- c(args, sql_quote(remote, "'"))
   if (force) args <- c(args, "'--force'")
-  query <- paste0("select dolt_fetch(", paste0(args, collapse = ", "), ")")
+  query <- paste0("call dolt_fetch(", paste0(args, collapse = ", "), ")")
   dolt_query(query, conn, collect, show_sql)
   invisible(dolt_state())
 }

--- a/R/dolt-remote.R
+++ b/R/dolt-remote.R
@@ -24,7 +24,7 @@ dolt_push <- function(remote = NULL, remote_branch = NULL, ref = NULL,
   if (set_upstream) args <- c("'--set-upstream' ", args)
   if (force) args <- c(args, "'--force'")
   query <- paste0("call dolt_push(", paste0(args, collapse = ", "), ")")
-  dolt_query(query, conn, collect, show_sql)
+  dolt_query(query, conn, collect, show_sql, execute = T)
   invisible(dolt_state())
 }
 

--- a/R/dolt-remote.R
+++ b/R/dolt-remote.R
@@ -24,7 +24,7 @@ dolt_push <- function(remote = NULL, remote_branch = NULL, ref = NULL,
   if (set_upstream) args <- c("'--set-upstream' ", args)
   if (force) args <- c(args, "'--force'")
   query <- paste0("call dolt_push(", paste0(args, collapse = ", "), ")")
-  dolt_query(query, conn, collect, show_sql, execute = T)
+  dolt_call(query, conn, show_sql)
   invisible(dolt_state())
 }
 
@@ -40,7 +40,7 @@ dolt_pull <- function(remote = NULL, squash = FALSE, conn = dolt(),
   if (!is.null(remote)) args <- c(args, sql_quote(remote, "'"))
   if (squash) args <- c(args, "'--squash'")
   query <- paste0("call dolt_pull(", paste0(args, collapse = ", "), ")")
-  dolt_query(query, conn, collect, show_sql)
+  dolt_call(query, conn, show_sql)
   invisible(dolt_state())
 }
 
@@ -55,7 +55,7 @@ dolt_fetch <- function(remote = NULL, ref = FALSE, force = FALSE,
   if (!is.null(ref)) args <- c(args, sql_quote(remote, "'"))
   if (force) args <- c(args, "'--force'")
   query <- paste0("call dolt_fetch(", paste0(args, collapse = ", "), ")")
-  dolt_query(query, conn, collect, show_sql)
+  dolt_call(query, conn, show_sql)
   invisible(dolt_state())
 }
 

--- a/R/dolt-stage-commit.R
+++ b/R/dolt-stage-commit.R
@@ -9,7 +9,7 @@ dolt_add <- function(tables = NULL, conn = dolt(), collect = NULL, show_sql = NU
     tables <- "'--all'"
   else
     tables <- paste0("'", tables, "'", collapse = ", ")
-  query <- paste0("select dolt_add(", tables, ")");
+  query <- paste0("call dolt_add(", tables, ")");
   dolt_query(query, conn, collect, show_sql)
   invisible(dolt_status())
 }
@@ -44,7 +44,7 @@ dolt_commit <- function(all = TRUE, message = NULL, author = NULL, date = NULL,
   if (!is.null(author)) args <- c(args, "'--author'", paste0("'", author, "'"))
   if (!is.null(date)) args <- c(args, "'--date'", paste0("'", date, "'"))
   if (allow_empty) args <- c(args, "'--allow-empty'")
-  query <- paste0("select dolt_commit(", paste0(args, collapse = ", "), ")");
+  query <- paste0("call dolt_commit(", paste0(args, collapse = ", "), ")");
   dolt_query(query, conn, collect, show_sql)
   invisible(dolt_state())
 }

--- a/R/dolt-stage-commit.R
+++ b/R/dolt-stage-commit.R
@@ -10,7 +10,7 @@ dolt_add <- function(tables = NULL, conn = dolt(), collect = NULL, show_sql = NU
   else
     tables <- paste0("'", tables, "'", collapse = ", ")
   query <- paste0("call dolt_add(", tables, ")");
-  dolt_query(query, conn, collect, show_sql)
+  dolt_query(query, conn, collect, show_sql, execute = T)
   invisible(dolt_status())
 }
 
@@ -45,7 +45,7 @@ dolt_commit <- function(all = TRUE, message = NULL, author = NULL, date = NULL,
   if (!is.null(date)) args <- c(args, "'--date'", paste0("'", date, "'"))
   if (allow_empty) args <- c(args, "'--allow-empty'")
   query <- paste0("call dolt_commit(", paste0(args, collapse = ", "), ")");
-  dolt_query(query, conn, collect, show_sql)
+  dolt_query(query, conn, collect, show_sql, execute = T)
   invisible(dolt_state())
 }
 
@@ -63,6 +63,6 @@ dolt_reset <- function(hard = FALSE, tables = NULL, conn = dolt(),
   if (!is.null(tables)) args <- paste0(sql_quote(tables, "'"), collapse = ", ")
   if (hard) args <- c(sql_quote("--hard", "'"), args)
   query <- paste0("call dolt_reset(", paste(args, collapse = ", ", ")"))
-  dolt_query(query, conn, collect, show_sql)
+  dolt_query(query, conn, collect, show_sql, execute = T)
   invisible(dolt_state())
 }

--- a/R/dolt-stage-commit.R
+++ b/R/dolt-stage-commit.R
@@ -62,7 +62,7 @@ dolt_reset <- function(hard = FALSE, tables = NULL, conn = dolt(),
   args <- c()
   if (!is.null(tables)) args <- paste0(sql_quote(tables, "'"), collapse = ", ")
   if (hard) args <- c(sql_quote("--hard", "'"), args)
-  query <- paste0("select dolt_reset(", paste(args, collapse = ", ", ")"))
+  query <- paste0("call dolt_reset(", paste(args, collapse = ", ", ")"))
   dolt_query(query, conn, collect, show_sql)
   invisible(dolt_state())
 }

--- a/R/dolt-stage-commit.R
+++ b/R/dolt-stage-commit.R
@@ -10,7 +10,7 @@ dolt_add <- function(tables = NULL, conn = dolt(), collect = NULL, show_sql = NU
   else
     tables <- paste0("'", tables, "'", collapse = ", ")
   query <- paste0("call dolt_add(", tables, ")");
-  dolt_query(query, conn, collect, show_sql, execute = T)
+  dolt_call(query, conn, show_sql)
   invisible(dolt_status())
 }
 
@@ -45,8 +45,10 @@ dolt_commit <- function(all = TRUE, message = NULL, author = NULL, date = NULL,
   if (!is.null(date)) args <- c(args, "'--date'", paste0("'", date, "'"))
   if (allow_empty) args <- c(args, "'--allow-empty'")
   query <- paste0("call dolt_commit(", paste0(args, collapse = ", "), ")");
-  dolt_query(query, conn, collect, show_sql, execute = T)
-  invisible(dolt_state())
+  dolt_call(query, conn, show_sql)
+  state <- dolt_state()
+  message(paste0("head commit: ", state$head))
+  invisible(state)
 }
 
 #' @param hard Reset working and staged tables? If FALSE (default), a "soft"
@@ -63,6 +65,6 @@ dolt_reset <- function(hard = FALSE, tables = NULL, conn = dolt(),
   if (!is.null(tables)) args <- paste0(sql_quote(tables, "'"), collapse = ", ")
   if (hard) args <- c(sql_quote("--hard", "'"), args)
   query <- paste0("call dolt_reset(", paste(args, collapse = ", ", ")"))
-  dolt_query(query, conn, collect, show_sql, execute = T)
+  dolt_call(query, conn, show_sql)
   invisible(dolt_state())
 }

--- a/R/query.R
+++ b/R/query.R
@@ -7,10 +7,10 @@ dolt_query <- function(query, conn = dolt(),
   if (show_sql) message(query)
   if(!execute) {
     result <- tbl(conn, query)
+    if (collect) result <- collect(result)
   } else {
     result <- RMariaDB::dbExecute(conn, query)
   }
-  if (collect) result <- collect(result)
   result
 }
 

--- a/R/query.R
+++ b/R/query.R
@@ -1,19 +1,13 @@
 #' @importFrom dplyr tbl collect sql
 dolt_query <- function(query, conn = dolt(),
                        collect = Sys.getboolenv("DOLT_COLLECT", TRUE),
-                       show_sql = Sys.getboolenv("DOLT_VERBOSE", FALSE),
-                       execute = F) {
+                       show_sql = Sys.getboolenv("DOLT_VERBOSE", FALSE)) {
   query <- sql(query)
   if (show_sql) message(query)
-  if(!execute) {
-    result <- tbl(conn, query)
-    if (collect) result <- collect(result)
-  } else {
-    result <- RMariaDB::dbExecute(conn, query)
-  }
+  result <- tbl(conn, query)
+  if (collect) result <- collect(result)
   result
 }
-
 
 .collect <- function(collect) {
   if (is.null(collect))
@@ -28,3 +22,13 @@ dolt_query <- function(query, conn = dolt(),
   else
     return(show_sql)
 }
+
+dolt_call <- function(query, conn = dolt(),
+                    show_sql = Sys.getboolenv("DOLT_VERBOSE", FALSE)) {
+
+  query <- sql(query)
+  if (show_sql) message(query)
+  result <- RMariaDB::dbExecute(conn, query)
+  result
+}
+

--- a/R/query.R
+++ b/R/query.R
@@ -1,10 +1,15 @@
 #' @importFrom dplyr tbl collect sql
 dolt_query <- function(query, conn = dolt(),
                        collect = Sys.getboolenv("DOLT_COLLECT", TRUE),
-                       show_sql = Sys.getboolenv("DOLT_VERBOSE", FALSE)) {
+                       show_sql = Sys.getboolenv("DOLT_VERBOSE", FALSE),
+                       execute = F) {
   query <- sql(query)
   if (show_sql) message(query)
-  result <- tbl(conn, query)
+  if(!execute) {
+    result <- tbl(conn, query)
+  } else {
+    result <- RMariaDB::dbExecute(conn, query)
+  }
   if (collect) result <- collect(result)
   result
 }


### PR DESCRIPTION
I changed all the relevant syntax from SELECT to CALL according to this list: https://docs.dolthub.com/sql-reference/version-control/dolt-sql-procedures

Unfortunately dplyr's tbl can't handle dolt's new `CALL` syntax. As a patch I added an `execute` flag to dolt_query which then uses RMariaDB::dbExecute instead. However dbExecute doesn't report back as much as tbl so `collect` no longer makes sense in this context. It might make sense to build out an entire new function as these call procedures aren't really queries per se. 

For now though this seemed like the easiest way to get going. I've tested dolt_checkout which works as expected but haven't tested any of the other procedures yet.